### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ marshmallow-validators
     :target: https://travis-ci.org/marshmallow-code/marshmallow-validators
     :alt: Travis-CI
 
-Homepage: http://marshmallow-validators.rtfd.org/
+Homepage: https://marshmallow-validators.readthedocs.io/
 
 Use 3rd-party validators (e.g. from WTForms and colander) with marshmallow.
 
@@ -46,13 +46,13 @@ Get It Now
 Documentation
 =============
 
-Full documentation is available at http://marshmallow-validators.rtfd.org/ .
+Full documentation is available at https://marshmallow-validators.readthedocs.io/ .
 
 Project Links
 =============
 
-- Docs: http://marshmallow-validators.rtfd.org/
-- Changelog: http://marshmallow-validators.readthedocs.org/en/latest/changelog.html
+- Docs: https://marshmallow-validators.readthedocs.io/
+- Changelog: https://marshmallow-validators.readthedocs.io/en/latest/changelog.html
 - PyPI: https://pypi.python.org/pypi/marshmallow-validators
 - Issues: https://github.com/marshmallow-code/marshmallow-validators/issues
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,8 @@ primary_domain = 'py'
 default_role = 'py:obj'
 
 intersphinx_mapping = {
-    'python': ('http://python.readthedocs.org/en/latest/', None),
-    'marshmallow': ('http://marshmallow.readthedocs.org/en/latest/', None),
+    'python': ('https://python.readthedocs.io/en/latest/', None),
+    'marshmallow': ('https://marshmallow.readthedocs.io/en/latest/', None),
 }
 
 issues_github_path = 'marshmallow-code/marshmallow-validators'


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
